### PR TITLE
Add "checkbatch" command to submit a single reflow job from a batch

### DIFF
--- a/aguamenti/check.py
+++ b/aguamenti/check.py
@@ -1,0 +1,48 @@
+# Import modified 'os' module with LC_LANG set so click doesn't complain
+from .os_utils import os, REFLOW_WORKFLOWS, sanitize_path
+
+import json
+import subprocess
+
+import click
+import pandas as pd
+
+from .reflow_utils import write_config, write_samples
+from .s3_utils import S3_INPUT_PATH, get_fastqs_as_r1_r2_columns
+
+
+REGION = 'west'
+WORKFLOW = 'rnaseq.rf'
+
+# Taxons (species) with available references
+SUPPORTED_TAXA = ('mus',)
+TAXA_GENOMES = {'mus': 'mouse/vM19'}
+
+
+@click.command(short_help="Submit the first line of a reflow runbatch "
+                          "samples.csv to check for errors")
+@click.option("--path", default='.',
+              help="Where to look for samples.csv and config.json files. "
+                   "Default is the current directory")
+def check_batch(path):
+    """Reflow run the first line of a samples.csv"""
+    path = sanitize_path(path)
+
+    samples = pd.read_csv(os.path.join(path, 'samples.csv'), index_col=0)
+
+    with open(os.path.join(path, 'config.json')) as f:
+        config = json.load(f)
+
+    program = config['program']
+
+    first_row = samples.iloc[0]
+    arguments = []
+    for key, value in first_row.items():
+        arguments.append(f'-{key}')
+        arguments.append(str(value))
+
+    command = ["reflow", "run", program] + arguments
+    print(command)
+
+    click.echo(f"Running '{' '.join(command)}'")
+    subprocess.run(command)

--- a/aguamenti/check.py
+++ b/aguamenti/check.py
@@ -2,14 +2,11 @@
 from .os_utils import os, sanitize_path, get_stdout_from_command
 
 from itertools import chain
-import json
 import subprocess
 
 import click
-import pandas as pd
 
 from .reflow_utils import SAMPLES_CSV, CONFIG_JSON, read_config, read_samples
-from .s3_utils import S3_INPUT_PATH, get_fastqs_as_r1_r2_columns
 
 
 REGION = 'west'
@@ -18,6 +15,7 @@ WORKFLOW = 'rnaseq.rf'
 # Taxons (species) with available references
 SUPPORTED_TAXA = ('mus',)
 TAXA_GENOMES = {'mus': 'mouse/vM19'}
+
 
 def get_parameter_order(reflow_program):
     lines = get_stdout_from_command(["reflow", "doc", reflow_program])

--- a/aguamenti/check.py
+++ b/aguamenti/check.py
@@ -1,13 +1,14 @@
 # Import modified 'os' module with LC_LANG set so click doesn't complain
-from .os_utils import os, REFLOW_WORKFLOWS, sanitize_path
+from .os_utils import os, sanitize_path, get_stdout_from_command
 
+from itertools import chain
 import json
 import subprocess
 
 import click
 import pandas as pd
 
-from .reflow_utils import write_config, write_samples
+from .reflow_utils import SAMPLES_CSV, CONFIG_JSON, read_config, read_samples
 from .s3_utils import S3_INPUT_PATH, get_fastqs_as_r1_r2_columns
 
 
@@ -17,6 +18,22 @@ WORKFLOW = 'rnaseq.rf'
 # Taxons (species) with available references
 SUPPORTED_TAXA = ('mus',)
 TAXA_GENOMES = {'mus': 'mouse/vM19'}
+
+def get_parameter_order(reflow_program):
+    lines = get_stdout_from_command(["reflow", "doc", reflow_program])
+
+    # Save the parameters from the command
+    parameter_order = []
+    for line in lines:
+        if line.startswith('val'):
+            val, parameter, *rest = line.split()
+            parameter_order.append(parameter)
+
+        # First section is always parameters, then function definitions.
+        # Ignore all function definitions since they're not parameters
+        if line.startswith('Declarations'):
+            break
+    return parameter_order
 
 
 @click.command(short_help="Submit the first line of a reflow runbatch "
@@ -28,21 +45,26 @@ def check_batch(path):
     """Reflow run the first line of a samples.csv"""
     path = sanitize_path(path)
 
-    samples = pd.read_csv(os.path.join(path, 'samples.csv'), index_col=0)
-
-    with open(os.path.join(path, 'config.json')) as f:
-        config = json.load(f)
+    samples = read_samples(os.path.join(path, SAMPLES_CSV))
+    config = read_config(os.path.join(path, CONFIG_JSON))
 
     program = config['program']
 
+    parameter_order = get_parameter_order(program)
+
     first_row = samples.iloc[0]
-    arguments = []
+    arguments = {}
     for key, value in first_row.items():
-        arguments.append(f'-{key}')
-        arguments.append(str(value))
+        arguments[key] = str(value)
 
-    command = ["reflow", "run", program] + arguments
-    print(command)
+    arguments_ordered = list(chain(*[
+        # Add '-' before parameter name to show it's a flag
+        (f"-{param}", arguments[param]) for param in parameter_order
+    ]))
 
+    command = ["reflow", "run", program] + arguments_ordered
+
+    click.echo("---")
     click.echo(f"Running '{' '.join(command)}'")
+    click.echo("---")
     subprocess.run(command)

--- a/aguamenti/check.py
+++ b/aguamenti/check.py
@@ -53,7 +53,7 @@ def check_batch(path):
     samples = read_samples(os.path.join(path, SAMPLES_CSV))
     config = read_config(os.path.join(path, CONFIG_JSON))
 
-    program = config['program']
+    program = os.path.join(path, config['program'])
 
     parameter_order = get_parameter_order(program)
 

--- a/aguamenti/commandline.py
+++ b/aguamenti/commandline.py
@@ -5,8 +5,9 @@ from .os_utils import os  # noqa: F401
 
 import click
 
-from .rnaseq import align
-from .status import listbatches
+from aguamenti.rnaseq import align
+from aguamenti.status import listbatches
+from aguamenti.check import check_batch
 
 settings = dict(help_option_names=['-h', '--help'])
 
@@ -22,6 +23,7 @@ def cli():
 
 cli.add_command(align, name='rnaseq-align')
 cli.add_command(listbatches, name="status")
+cli.add_command(check_batch, name="check-batch")
 
 if __name__ == "__main__":
     cli()

--- a/aguamenti/os_utils.py
+++ b/aguamenti/os_utils.py
@@ -43,4 +43,3 @@ def get_stdout_from_command(command):
     lines = result.stdout.decode("utf-8").splitlines()
     lines = [x.strip() for x in lines]
     return lines
-

--- a/aguamenti/os_utils.py
+++ b/aguamenti/os_utils.py
@@ -1,4 +1,6 @@
 import os
+import subprocess
+
 
 # Set input language USA unicode encoding setting
 # Necessary because click assumes ascii input unless otherwise specified
@@ -22,3 +24,23 @@ def maybe_add_slash(path):
     """Add a final trailing slash if it wasn't there already"""
     with_trailing_slash = path if path.endswith('/') else path + '/'
     return with_trailing_slash
+
+
+def get_stdout_from_command(command):
+    """Run a program on the command line, and save the stdout
+
+    Parameters
+    ----------
+    command : list
+        list of strings to submit to subprocess.run
+
+    Returns
+    -------
+    lines : list
+        Newline-separated strings from output of command
+    """
+    result = subprocess.run(command, stdout=subprocess.PIPE)
+    lines = result.stdout.decode("utf-8").splitlines()
+    lines = [x.strip() for x in lines]
+    return lines
+

--- a/aguamenti/os_utils.py
+++ b/aguamenti/os_utils.py
@@ -26,6 +26,12 @@ def maybe_add_slash(path):
     return with_trailing_slash
 
 
+def decode(stderr_or_stdout):
+    decoded = stderr_or_stdout.decode("utf-8").splitlines()
+    lines = [x.strip() for x in decoded]
+    return lines
+
+
 def get_stdout_from_command(command):
     """Run a program on the command line, and save the stdout
 
@@ -40,6 +46,25 @@ def get_stdout_from_command(command):
         Newline-separated strings from output of command
     """
     result = subprocess.run(command, stdout=subprocess.PIPE)
-    lines = result.stdout.decode("utf-8").splitlines()
-    lines = [x.strip() for x in lines]
+    lines = decode(result.stdout)
     return lines
+
+
+def get_stdout_stderr_from_command(command):
+    """Run a program on the command line, and save the stdout
+
+    Parameters
+    ----------
+    command : list
+        list of strings to submit to subprocess.run
+
+    Returns
+    -------
+    lines : list
+        Newline-separated strings from output of command
+    """
+    result = subprocess.run(command, stdout=subprocess.PIPE,
+                            stderr=subprocess.PIPE)
+    stdout = decode(result.stdout)
+    stderr = decode(result.stderr)
+    return stdout, stderr

--- a/aguamenti/reflow_utils.py
+++ b/aguamenti/reflow_utils.py
@@ -2,6 +2,9 @@ import click
 import json
 import os
 
+import pandas as pd
+
+
 SAMPLES_CSV = 'samples.csv'
 CONFIG_JSON = 'config.json'
 
@@ -24,3 +27,13 @@ def write_samples(output, samples):
     samples.to_csv(csv)
     click.echo("\tDone.")
     return csv
+
+
+def read_config(config_filename):
+    with open(config_filename) as f:
+        config = json.load(f)
+    return config
+
+
+def read_samples(csv_filename):
+    return pd.read_csv(csv_filename, index_col=0)

--- a/aguamenti/rnaseq.py
+++ b/aguamenti/rnaseq.py
@@ -34,7 +34,7 @@ TAXA_GENOMES = {'mus': 'mouse/vM19'}
               help="Either 'east' or 'west', depending on where your fastq "
                    f"files are. Default: {REGION}")
 @click.option('--workflow', default=WORKFLOW,
-              help="Which workflow to run on these files. " \
+              help="Which workflow to run on these files. "
                    f"Default: {WORKFLOW}")
 def align(experiment_id, taxon, s3_output_path, s3_input_path=S3_INPUT_PATH,
           output='.', reflow_workflows_path=REFLOW_WORKFLOWS,

--- a/aguamenti/status.py
+++ b/aguamenti/status.py
@@ -28,7 +28,10 @@ def traverse_find_reflow_batch_dirs(dirname):
 
 def echo_n_status(n_statuses, n_total):
     for status, n in sorted(n_statuses.items()):
-        click.echo(f"\t{status}:\t{n}/{n_total}\t({100*n/n_total:.3f}%)")
+        # "done" is short relative to other statuses, so pad with one extra
+        # tab so it looks nice
+        sep = '\t' if status != 'done' else '\t\t'
+        click.echo(f"\t{status}:{sep}{n}/{n_total}\t({100*n/n_total:.3f}%)")
 
 
 @click.command(short_help="Summarize done/running/waiting/canceled reflow "

--- a/aguamenti/status.py
+++ b/aguamenti/status.py
@@ -1,8 +1,8 @@
 # Import modified 'os' module with LC_LANG set so click doesn't complain
-from .os_utils import os, REFLOW_BATCHES, sanitize_path
+from .os_utils import os, REFLOW_BATCHES, sanitize_path, \
+    get_stdout_from_command
 
 from collections import defaultdict
-import subprocess
 
 
 import click
@@ -48,14 +48,11 @@ def listbatches(path, n_last_words=4):
     for reflow_batch_dir in reflow_batch_dirs:
         os.chdir(reflow_batch_dir)
 
-        listbatch = subprocess.run(["reflow", "listbatch"],
-                                   stdout=subprocess.PIPE)
-        lines = listbatch.stdout.decode("utf-8").splitlines()
+        lines = get_stdout_from_command(["reflow", "listbatch"])
 
         n_known_statuses = dict.fromkeys(KNOWN_STATUSES, 0)
         n_other_statuses = defaultdict(int)
         for line in lines:
-            line = line.strip()
             matched_status = False
             for status in KNOWN_STATUSES:
                 if line.endswith(status):

--- a/aguamenti/tests/data/check/config.json
+++ b/aguamenti/tests/data/check/config.json
@@ -1,0 +1,1 @@
+{"program": "greet.rf", "runs_file": "samples.csv"}

--- a/aguamenti/tests/data/check/greet.rf
+++ b/aguamenti/tests/data/check/greet.rf
@@ -1,0 +1,12 @@
+param (
+    // Whom to greet
+    whom string
+
+    // The greeting itself
+    greeting string
+)
+
+
+val Main = exec(image := "ubuntu", mem := GiB) (out file) {"
+	echo {{greeting}} {{whom}} >>{{out}}
+"}

--- a/aguamenti/tests/data/check/greet_syntax_error.rf
+++ b/aguamenti/tests/data/check/greet_syntax_error.rf
@@ -1,0 +1,12 @@
+param (
+    // Whom to greet
+    whom "hello"
+
+    // The greeting itself
+    greeting
+)
+
+
+val Main = exec(image := "ubuntu", mem := GiB) (out file) {"
+	echo {{greeting}} {{whom}} >>{{out}}
+"}

--- a/aguamenti/tests/data/check/samples.csv
+++ b/aguamenti/tests/data/check/samples.csv
@@ -1,0 +1,5 @@
+id,whom,greeting
+english,world,hello
+russian,mir,privet
+french,le monde,bonjour
+japanese,sekai,konnichiwa

--- a/aguamenti/tests/test_check.py
+++ b/aguamenti/tests/test_check.py
@@ -52,8 +52,9 @@ def test_check_batch(check_folder):
 
     captured = result.output
 
-    true = '---\nFound sample with id "english"!\nRunning \'' \
-           'reflow run hello.rf\'\n---\n'
+    found_sample = '---\nFound sample with id "english"'
+    running = 'greet.rf -whom world -greeting hello\'\n---\n'
 
     assert isinstance(captured, object)
-    assert true in captured
+    assert found_sample in captured
+    assert running in captured

--- a/aguamenti/tests/test_check.py
+++ b/aguamenti/tests/test_check.py
@@ -1,0 +1,59 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+import os
+
+from click.testing import CliRunner
+import pytest
+
+
+@pytest.fixture
+def check_folder(data_folder):
+    return os.path.join(data_folder, 'check')
+
+
+@pytest.fixture
+def reflow_program():
+    return "greet.rf"
+
+
+@pytest.fixture
+def reflow_program_syntax_error():
+    return "greet_syntax_error.rf"
+
+
+def test_get_parameter_order(check_folder, reflow_program):
+    from aguamenti.check import get_parameter_order
+
+    program_full_path = os.path.join(check_folder, reflow_program)
+
+    test = get_parameter_order(program_full_path)
+    true = ['whom', 'greeting']
+    assert test == true
+
+
+def test_get_parameter_order_syntax_error(check_folder,
+                                          reflow_program_syntax_error):
+    from aguamenti.check import get_parameter_order
+
+    program_full_path = os.path.join(check_folder, reflow_program_syntax_error)
+
+    with pytest.raises(ValueError):
+        get_parameter_order(program_full_path)
+
+
+def test_check_batch(check_folder):
+    from aguamenti.check import check_batch
+
+    runner = CliRunner()
+    result = runner.invoke(check_batch, ['--path', check_folder])
+
+    # exit code of '0' means success!
+    assert result.exit_code == 0
+
+    captured = result.output
+
+    true = '---\nFound sample with id "english"!\nRunning \'' \
+           'reflow run hello.rf\'\n---\n'
+
+    assert isinstance(captured, object)
+    assert true in captured


### PR DESCRIPTION
A lot of times I find myself submitting a huge reflow job but then it totally fails for a simple reason like a syntax error. It's really annoying to spin up a bunch of instances and then they all go away. This command runs the first sample line of a `samples.csv` file via `reflow run program.rf` and all the parameters.

### Test workflow

E.g. for the following `greet.rf` workflow:

```
param (
    // Whom to greet
    whom string

    // The greeting itself
    greeting string
)


val Main = exec(image := "ubuntu", mem := GiB) (out file) {"
	echo {{greeting}} {{whom}} >>{{out}}
"}
```

### Test samples.csv

This samples.csv:

```
id,whom,greeting
english,world,hello
russian,mir,privet
french,le monde,bonjour
japanese,sekai,konnichiwa
```

### Test output

Here's the output:

```
 Fri 25 Jan - 08:57  ~/code/aguamenti   origin ☊ olgabot/check-batch 1● 
  aguamenti check-batch --path aguamenti/tests/data/check/
---
Found sample with id "english"!
Running 'reflow run /Users/olgabot/code/aguamenti/aguamenti/tests/data/check/greet.rf -whom world -greeting hello'
---
reflow: run ID: 5c6caff2
ec2cluster: 0 instances:  (<=$0.0/hr), total{}, waiting{}, pending{}
  allocate {mem:1.0GiB cpu:1 disk:1.0GiB}:    1s

```