### PR TITLE
Turn off the cache for check-batch to force evaluation

### DIFF
--- a/aguamenti/check.py
+++ b/aguamenti/check.py
@@ -71,7 +71,8 @@ def check_batch(path, debug):
     ]))
 
     if debug:
-        base_command = ["reflow", "-log=debug", "-cache=off", "run", "-trace", program]
+        base_command = ["reflow", "-log=debug", "-cache=off", "run", "-trace",
+                        program]
     else:
         base_command = ["reflow", "run", program]
 

--- a/aguamenti/check.py
+++ b/aguamenti/check.py
@@ -71,7 +71,7 @@ def check_batch(path, debug):
     ]))
 
     if debug:
-        base_command = ["reflow", "-log=debug", "run", "-trace", program]
+        base_command = ["reflow", "-log=debug", "-cache=off", "run", "-trace", program]
     else:
         base_command = ["reflow", "run", program]
 

--- a/aguamenti/tests/test_check.py
+++ b/aguamenti/tests/test_check.py
@@ -77,4 +77,4 @@ def test_check_batch_debug(check_folder):
     assert isinstance(captured, object)
     assert found_sample in captured
     assert running in captured
-    assert 'reflow -log=debug run -trace' in captured
+    assert 'reflow -log=debug -cache=off run -trace' in captured


### PR DESCRIPTION
Adds `-cache=off` flag to reflow run command of check-batch, e.g.:

```
reflow -log=debug -cache=off run -trace /Users/olgabot/code/aguamenti/aguamenti/tests/data/check/greet.rf -whom world -greeting hello
```